### PR TITLE
refactor: Migrate RPC framework from tarpc to tonic (gRPC)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - uses: arduino/setup-protoc@v3
+
       - name: Run tests
         run: cargo test --all --verbose
 
@@ -41,6 +43,8 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+
+      - uses: arduino/setup-protoc@v3
 
       - name: Run clippy
         run: cargo clippy --all --all-targets -- -D warnings
@@ -74,6 +78,8 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+
+      - uses: arduino/setup-protoc@v3
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: arduino/setup-protoc@v3
       - name: Build maelstrom-ikada binary
         run: cargo build --release --bin maelstrom-ikada
       - name: Upload binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: arduino/setup-protoc@v3
+
       - name: Upload Rust binary
         uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +124,59 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -238,42 +313,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "env_filter"
@@ -301,6 +344,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,21 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
@@ -392,7 +442,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -439,12 +488,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -511,10 +566,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
+name = "httpdate"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -530,6 +585,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -569,7 +625,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -687,21 +743,32 @@ dependencies = [
  "bincode",
  "bytes",
  "clap",
- "futures",
  "inferno",
  "nom",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
  "rand 0.9.2",
  "serde",
  "serde_json",
- "tarpc",
  "thiserror",
  "tokio",
+ "tonic 0.12.3",
+ "tonic-build",
  "tracing",
- "tracing-opentelemetry 0.32.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -726,7 +793,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap",
+ "indexmap 2.12.0",
  "is-terminal",
  "itoa",
  "log",
@@ -808,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,10 +911,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -859,6 +944,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nom"
@@ -903,20 +994,6 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -938,7 +1015,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -949,15 +1026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
- "prost",
+ "opentelemetry_sdk",
+ "prost 0.14.1",
  "reqwest",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.14.2",
  "tracing",
 ]
 
@@ -967,32 +1044,11 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
- "prost",
- "tonic",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.1",
+ "tonic 0.14.2",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.30.0",
- "percent-encoding",
- "rand 0.9.2",
- "thiserror",
 ]
 
 [[package]]
@@ -1004,7 +1060,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror",
@@ -1028,6 +1084,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.12.0",
+]
 
 [[package]]
 name = "pin-project"
@@ -1080,6 +1146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,12 +1166,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.1",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1109,6 +1228,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -1204,6 +1332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1385,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1261,6 +1401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1368,6 +1521,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -1381,12 +1544,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
@@ -1432,39 +1589,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tarpc"
-version = "0.37.0"
+name = "tempfile"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cb86a4b5b941909e9896289c01b46ff0bec756b01f366b0d5490a5e8ed7871"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
- "anyhow",
- "fnv",
- "futures",
- "humantime",
- "opentelemetry 0.30.0",
- "opentelemetry-semantic-conventions",
- "pin-project",
- "rand 0.8.5",
- "serde",
- "static_assertions",
- "tarpc-plugins",
- "thiserror",
- "tokio",
- "tokio-serde",
- "tokio-util",
- "tracing",
- "tracing-opentelemetry 0.31.0",
-]
-
-[[package]]
-name = "tarpc-plugins"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ef4401b013b1f5218ba33ea8f1eddbfcc00ec8db073ef995c192e71f08f027"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1517,7 +1651,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1531,22 +1665,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1570,8 +1688,37 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "slab",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1594,10 +1741,24 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1607,8 +1768,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.1",
+ "tonic 0.14.2",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1619,7 +1800,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.12.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -1643,7 +1824,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1666,7 +1847,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1706,29 +1886,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
-dependencies = [
- "js-sys",
- "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "web-time",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "rustversion",
  "smallvec",
  "thiserror",
@@ -1915,11 +2079,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1933,20 +2106,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1956,9 +2151,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1968,9 +2175,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1980,15 +2199,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -87,28 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,18 +104,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -150,29 +121,26 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -455,17 +423,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -488,18 +445,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -625,7 +576,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -748,27 +699,18 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "rand 0.9.2",
+ "prost",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tonic 0.12.3",
- "tonic-build",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -793,7 +735,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.12.0",
+ "indexmap",
  "is-terminal",
  "itoa",
  "log",
@@ -912,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1030,11 +972,11 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.1",
+ "prost",
  "reqwest",
  "thiserror",
  "tokio",
- "tonic 0.14.2",
+ "tonic",
  "tracing",
 ]
 
@@ -1046,8 +988,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.1",
- "tonic 0.14.2",
+ "prost",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -1062,7 +1004,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand",
  "thiserror",
 ]
 
@@ -1092,7 +1034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.12.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1166,29 +1108,19 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools",
@@ -1197,24 +1129,13 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.5",
+ "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1232,11 +1153,31 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "prost 0.13.5",
+ "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "21.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1265,33 +1206,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1301,16 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1319,7 +1230,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -1385,7 +1296,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -1521,16 +1432,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -1595,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1651,7 +1552,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1693,11 +1594,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -1711,37 +1611,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1749,14 +1623,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
  "quote",
  "syn",
 ]
@@ -1768,28 +1640,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
- "tonic 0.14.2",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost-build"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1800,7 +1668,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -1824,7 +1692,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1926,6 +1794,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2079,20 +1953,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2106,42 +1971,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2151,21 +1994,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2175,21 +2006,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2199,33 +2018,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,20 @@ nom = "7"
 opentelemetry = "0.31.0"
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.31.0"
-prost = "0.13"
+prost = "0.14"
+tonic-prost = "0.14"
 rand = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.17"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "test-util", "fs"] }
-tonic = "0.12"
+tonic = "0.14"
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-prost-build = "0.14"
 
 [[bin]]
 name = "maelstrom-ikada"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,23 @@ base64 = "0.22"
 bincode = "1.3.3"
 bytes = { version = "1.11.0", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
-futures = "0.3"
 nom = "7"
 opentelemetry = "0.31.0"
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.31.0"
+prost = "0.13"
 rand = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tarpc = { version = "0.37", features = ["full"] }
 thiserror = "2.0.17"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "test-util", "fs"] }
+tonic = "0.12"
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+
+[build-dependencies]
+tonic-build = "0.12"
 
 [[bin]]
 name = "maelstrom-ikada"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/raft.proto")?;
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/raft.proto")?;
+    tonic_prost_build::compile_protos("proto/raft.proto")?;
     Ok(())
 }

--- a/integ/maelstrom_network.rs
+++ b/integ/maelstrom_network.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tarpc::context;
 use tokio::sync::{Mutex, mpsc, oneshot};
 
 use crate::maelstrom::*;
@@ -162,7 +161,7 @@ impl MaelstromRpcClient {
 impl RaftRpcTrait for MaelstromRpcClient {
     async fn append_entries(
         &self,
-        ctx: context::Context,
+        ctx: RpcContext,
         req: AppendEntriesRequest,
     ) -> anyhow::Result<AppendEntriesResponse> {
         let dest = match self.node_id_to_string(self.node_id).await {
@@ -203,9 +202,8 @@ impl RaftRpcTrait for MaelstromRpcClient {
             }),
         };
 
-        let timeout = ctx
-            .deadline
-            .saturating_duration_since(std::time::Instant::now());
+        let timeout =
+            ctx.timeout().unwrap_or(std::time::Duration::from_secs(5));
 
         match self.send_and_wait(msg, msg_id, timeout).await {
             Ok(response) => match response.body {
@@ -226,7 +224,7 @@ impl RaftRpcTrait for MaelstromRpcClient {
 
     async fn request_vote(
         &self,
-        ctx: context::Context,
+        ctx: RpcContext,
         req: RequestVoteRequest,
     ) -> anyhow::Result<RequestVoteResponse> {
         let dest = match self.node_id_to_string(self.node_id).await {
@@ -253,9 +251,8 @@ impl RaftRpcTrait for MaelstromRpcClient {
             }),
         };
 
-        let timeout = ctx
-            .deadline
-            .saturating_duration_since(std::time::Instant::now());
+        let timeout =
+            ctx.timeout().unwrap_or(std::time::Duration::from_secs(5));
 
         match self.send_and_wait(msg, msg_id, timeout).await {
             Ok(response) => match response.body {
@@ -276,7 +273,7 @@ impl RaftRpcTrait for MaelstromRpcClient {
 
     async fn client_request(
         &self,
-        _ctx: context::Context,
+        _ctx: RpcContext,
         _req: CommandRequest,
     ) -> anyhow::Result<CommandResponse> {
         Ok(CommandResponse {
@@ -291,7 +288,7 @@ impl RaftRpcTrait for MaelstromRpcClient {
 
     async fn install_snapshot(
         &self,
-        _ctx: context::Context,
+        _ctx: RpcContext,
         _req: InstallSnapshotRequest,
     ) -> anyhow::Result<InstallSnapshotResponse> {
         Ok(InstallSnapshotResponse { term: Term::new(0) })

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package raft;
+
+service RaftRpc {
+  rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse);
+  rpc RequestVote(RequestVoteRequest) returns (RequestVoteResponse);
+  rpc ClientRequest(CommandRequest) returns (CommandResponse);
+  rpc InstallSnapshot(InstallSnapshotRequest) returns (InstallSnapshotResponse);
+}
+
+message LogEntry {
+  uint32 term = 1;
+  bytes command = 2;
+}
+
+message AppendEntriesRequest {
+  uint32 term = 1;
+  uint32 leader_id = 2;
+  uint32 prev_log_index = 3;
+  uint32 prev_log_term = 4;
+  repeated LogEntry entries = 5;
+  uint32 leader_commit = 6;
+}
+
+message AppendEntriesResponse {
+  uint32 term = 1;
+  bool success = 2;
+}
+
+message RequestVoteRequest {
+  uint32 term = 1;
+  uint32 candidate_id = 2;
+  uint32 last_log_index = 3;
+  uint32 last_log_term = 4;
+}
+
+message RequestVoteResponse {
+  uint32 term = 1;
+  bool vote_granted = 2;
+}
+
+message CommandRequest {
+  bytes command = 1;
+}
+
+enum CommandErrorKind {
+  COMMAND_ERROR_KIND_UNSPECIFIED = 0;
+  COMMAND_ERROR_KIND_NOT_LEADER = 1;
+  COMMAND_ERROR_KIND_NOOP_NOT_COMMITTED = 2;
+  COMMAND_ERROR_KIND_REPLICATION_FAILED = 3;
+  COMMAND_ERROR_KIND_OTHER = 4;
+}
+
+message CommandResponse {
+  bool success = 1;
+  bool has_leader_hint = 2;
+  uint32 leader_hint = 3;
+  bool has_data = 4;
+  bytes data = 5;
+  bool has_error = 6;
+  CommandErrorKind error_kind = 7;
+  string error_message = 8;
+}
+
+message InstallSnapshotRequest {
+  uint32 term = 1;
+  uint32 leader_id = 2;
+  uint32 last_included_index = 3;
+  uint32 last_included_term = 4;
+  bytes data = 5;
+}
+
+message InstallSnapshotResponse {
+  uint32 term = 1;
+}

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use tracing::Instrument;
 
 use ikada::config::Config;
-use ikada::network::TarpcNetworkFactory;
+use ikada::network::TonicNetworkFactory;
 use ikada::node::Node;
 use ikada::statemachine::KVStateMachine;
 use ikada::trace::init_tracing;
@@ -93,7 +93,7 @@ async fn run() -> anyhow::Result<()> {
     let mut node = Node::builder(port)
         .config(config)
         .state_machine(KVStateMachine::default())
-        .network_factory(TarpcNetworkFactory::new())
+        .network_factory(TonicNetworkFactory::new())
         .storage(Box::new(FileStorage::new(args.storage_dir)))
         .build();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tarpc::context;
 
-use crate::network::{NetworkFactory, TarpcNetworkFactory};
-use crate::rpc::{CommandRequest, RaftRpcTrait};
+use crate::network::{NetworkFactory, TonicNetworkFactory};
+use crate::rpc::{CommandRequest, RaftRpcTrait, RpcContext};
 use crate::statemachine::{KVCommand, KVResponse};
 
 pub struct RaftClient<NF: NetworkFactory> {
@@ -39,8 +38,7 @@ impl<NF: NetworkFactory> RaftClient<NF> {
     ) -> anyhow::Result<Vec<u8>> {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
-        let mut ctx = context::current();
-        ctx.deadline = std::time::Instant::now() + TIMEOUT;
+        let ctx = RpcContext::current().with_timeout(TIMEOUT);
 
         let request = CommandRequest {
             command: command.clone(),
@@ -74,8 +72,8 @@ impl<NF: NetworkFactory> RaftClient<NF> {
 
 pub struct KVStore {
     cluster_addrs: Vec<SocketAddr>,
-    current_client: Option<RaftClient<TarpcNetworkFactory>>,
-    network_factory: TarpcNetworkFactory,
+    current_client: Option<RaftClient<TonicNetworkFactory>>,
+    network_factory: TonicNetworkFactory,
     current_addr_index: usize,
 }
 
@@ -83,7 +81,7 @@ impl KVStore {
     pub async fn connect(
         cluster_addrs: Vec<SocketAddr>,
     ) -> anyhow::Result<Self> {
-        let network_factory = TarpcNetworkFactory::new();
+        let network_factory = TonicNetworkFactory::new();
         let mut store = Self {
             cluster_addrs,
             current_client: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ impl<NF: NetworkFactory> RaftClient<NF> {
     ) -> anyhow::Result<Vec<u8>> {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
-        let ctx = RpcContext::current().with_timeout(TIMEOUT);
+        let ctx = RpcContext::background().with_timeout(TIMEOUT);
 
         let request = CommandRequest {
             command: command.clone(),

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tarpc::{client, tokio_serde::formats::Json};
+use tarpc::{client, tokio_serde::formats::Bincode};
 
 use crate::rpc::{RaftRpcClient, RaftRpcTrait};
 
@@ -59,7 +59,7 @@ impl NetworkFactory for TarpcNetworkFactory {
         addr: SocketAddr,
     ) -> Result<Arc<dyn RaftRpcTrait>, NetworkError> {
         let transport =
-            tarpc::serde_transport::tcp::connect(addr, Json::default)
+            tarpc::serde_transport::tcp::connect(addr, Bincode::default)
                 .await
                 .map_err(|e| {
                     NetworkError::ConnectionFailed(format!(
@@ -245,10 +245,10 @@ pub mod mock {
                     Arc::clone(client)
                 } else {
                     use tarpc::client;
-                    use tarpc::tokio_serde::formats::Json;
+                    use tarpc::tokio_serde::formats::Bincode;
                     let transport = tarpc::serde_transport::tcp::connect(
                         addr,
-                        Json::default,
+                        Bincode::default,
                     )
                     .await
                     .map_err(|e| {

--- a/src/network.rs
+++ b/src/network.rs
@@ -63,13 +63,9 @@ impl RaftRpcTrait for TonicRpcClient {
         req: crate::rpc::AppendEntriesRequest,
     ) -> anyhow::Result<crate::rpc::AppendEntriesResponse> {
         let mut client = self.inner.clone();
-        let proto_req: proto::AppendEntriesRequest = (&req).into();
-        let mut request = tonic::Request::new(proto_req);
-        if let Some(timeout) = ctx.timeout() {
-            request.set_timeout(timeout);
-        }
-        let response = client.append_entries(request).await?;
-        Ok(response.into_inner().into())
+        let request =
+            ctx.into_tonic_request(proto::AppendEntriesRequest::from(&req));
+        Ok(client.append_entries(request).await?.into_inner().into())
     }
 
     async fn request_vote(
@@ -78,13 +74,9 @@ impl RaftRpcTrait for TonicRpcClient {
         req: crate::rpc::RequestVoteRequest,
     ) -> anyhow::Result<crate::rpc::RequestVoteResponse> {
         let mut client = self.inner.clone();
-        let proto_req: proto::RequestVoteRequest = (&req).into();
-        let mut request = tonic::Request::new(proto_req);
-        if let Some(timeout) = ctx.timeout() {
-            request.set_timeout(timeout);
-        }
-        let response = client.request_vote(request).await?;
-        Ok(response.into_inner().into())
+        let request =
+            ctx.into_tonic_request(proto::RequestVoteRequest::from(&req));
+        Ok(client.request_vote(request).await?.into_inner().into())
     }
 
     async fn client_request(
@@ -93,13 +85,8 @@ impl RaftRpcTrait for TonicRpcClient {
         req: crate::rpc::CommandRequest,
     ) -> anyhow::Result<crate::rpc::CommandResponse> {
         let mut client = self.inner.clone();
-        let proto_req: proto::CommandRequest = (&req).into();
-        let mut request = tonic::Request::new(proto_req);
-        if let Some(timeout) = ctx.timeout() {
-            request.set_timeout(timeout);
-        }
-        let response = client.client_request(request).await?;
-        Ok(response.into_inner().into())
+        let request = ctx.into_tonic_request(proto::CommandRequest::from(&req));
+        Ok(client.client_request(request).await?.into_inner().into())
     }
 
     async fn install_snapshot(
@@ -108,13 +95,9 @@ impl RaftRpcTrait for TonicRpcClient {
         req: crate::rpc::InstallSnapshotRequest,
     ) -> anyhow::Result<crate::rpc::InstallSnapshotResponse> {
         let mut client = self.inner.clone();
-        let proto_req: proto::InstallSnapshotRequest = (&req).into();
-        let mut request = tonic::Request::new(proto_req);
-        if let Some(timeout) = ctx.timeout() {
-            request.set_timeout(timeout);
-        }
-        let response = client.install_snapshot(request).await?;
-        Ok(response.into_inner().into())
+        let request =
+            ctx.into_tonic_request(proto::InstallSnapshotRequest::from(&req));
+        Ok(client.install_snapshot(request).await?.into_inner().into())
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tarpc::{client, tokio_serde::formats::Bincode};
 
-use crate::rpc::{RaftRpcClient, RaftRpcTrait};
+use crate::rpc::{RaftRpcTrait, RpcContext, proto};
 
 #[async_trait]
 pub trait NetworkFactory: Send + Sync {
@@ -38,40 +37,112 @@ impl From<anyhow::Error> for NetworkError {
 }
 
 #[derive(Clone)]
-pub struct TarpcNetworkFactory;
+pub struct TonicNetworkFactory;
 
-impl TarpcNetworkFactory {
+impl TonicNetworkFactory {
     pub fn new() -> Self {
         Self
     }
 }
 
-impl Default for TarpcNetworkFactory {
+impl Default for TonicNetworkFactory {
     fn default() -> Self {
         Self::new()
     }
 }
 
+struct TonicRpcClient {
+    inner: proto::raft_rpc_client::RaftRpcClient<tonic::transport::Channel>,
+}
+
 #[async_trait]
-impl NetworkFactory for TarpcNetworkFactory {
+impl RaftRpcTrait for TonicRpcClient {
+    async fn append_entries(
+        &self,
+        ctx: RpcContext,
+        req: crate::rpc::AppendEntriesRequest,
+    ) -> anyhow::Result<crate::rpc::AppendEntriesResponse> {
+        let mut client = self.inner.clone();
+        let proto_req: proto::AppendEntriesRequest = (&req).into();
+        let mut request = tonic::Request::new(proto_req);
+        if let Some(timeout) = ctx.timeout() {
+            request.set_timeout(timeout);
+        }
+        let response = client.append_entries(request).await?;
+        Ok(response.into_inner().into())
+    }
+
+    async fn request_vote(
+        &self,
+        ctx: RpcContext,
+        req: crate::rpc::RequestVoteRequest,
+    ) -> anyhow::Result<crate::rpc::RequestVoteResponse> {
+        let mut client = self.inner.clone();
+        let proto_req: proto::RequestVoteRequest = (&req).into();
+        let mut request = tonic::Request::new(proto_req);
+        if let Some(timeout) = ctx.timeout() {
+            request.set_timeout(timeout);
+        }
+        let response = client.request_vote(request).await?;
+        Ok(response.into_inner().into())
+    }
+
+    async fn client_request(
+        &self,
+        ctx: RpcContext,
+        req: crate::rpc::CommandRequest,
+    ) -> anyhow::Result<crate::rpc::CommandResponse> {
+        let mut client = self.inner.clone();
+        let proto_req: proto::CommandRequest = (&req).into();
+        let mut request = tonic::Request::new(proto_req);
+        if let Some(timeout) = ctx.timeout() {
+            request.set_timeout(timeout);
+        }
+        let response = client.client_request(request).await?;
+        Ok(response.into_inner().into())
+    }
+
+    async fn install_snapshot(
+        &self,
+        ctx: RpcContext,
+        req: crate::rpc::InstallSnapshotRequest,
+    ) -> anyhow::Result<crate::rpc::InstallSnapshotResponse> {
+        let mut client = self.inner.clone();
+        let proto_req: proto::InstallSnapshotRequest = (&req).into();
+        let mut request = tonic::Request::new(proto_req);
+        if let Some(timeout) = ctx.timeout() {
+            request.set_timeout(timeout);
+        }
+        let response = client.install_snapshot(request).await?;
+        Ok(response.into_inner().into())
+    }
+}
+
+#[async_trait]
+impl NetworkFactory for TonicNetworkFactory {
     async fn connect(
         &self,
         addr: SocketAddr,
     ) -> Result<Arc<dyn RaftRpcTrait>, NetworkError> {
-        let transport =
-            tarpc::serde_transport::tcp::connect(addr, Bincode::default)
-                .await
+        let endpoint =
+            tonic::transport::Endpoint::from_shared(format!("http://{}", addr))
                 .map_err(|e| {
                     NetworkError::ConnectionFailed(format!(
-                        "Failed to connect to {}: {}",
+                        "Invalid endpoint {}: {}",
                         addr, e
                     ))
                 })?;
 
-        let client =
-            RaftRpcClient::new(client::Config::default(), transport).spawn();
+        let channel = endpoint.connect().await.map_err(|e| {
+            NetworkError::ConnectionFailed(format!(
+                "Failed to connect to {}: {}",
+                addr, e
+            ))
+        })?;
 
-        Ok(Arc::new(client))
+        let client = proto::raft_rpc_client::RaftRpcClient::new(channel);
+
+        Ok(Arc::new(TonicRpcClient { inner: client }))
     }
 }
 
@@ -94,7 +165,7 @@ pub mod mock {
     impl RaftRpcTrait for PartitionableRpcClient {
         async fn append_entries(
             &self,
-            ctx: tarpc::context::Context,
+            ctx: RpcContext,
             req: AppendEntriesRequest,
         ) -> anyhow::Result<AppendEntriesResponse> {
             let partitions = self.partitions.lock().await;
@@ -111,7 +182,7 @@ pub mod mock {
 
         async fn request_vote(
             &self,
-            ctx: tarpc::context::Context,
+            ctx: RpcContext,
             req: RequestVoteRequest,
         ) -> anyhow::Result<RequestVoteResponse> {
             let partitions = self.partitions.lock().await;
@@ -128,7 +199,7 @@ pub mod mock {
 
         async fn client_request(
             &self,
-            ctx: tarpc::context::Context,
+            ctx: RpcContext,
             req: CommandRequest,
         ) -> anyhow::Result<CommandResponse> {
             let partitions = self.partitions.lock().await;
@@ -145,7 +216,7 @@ pub mod mock {
 
         async fn install_snapshot(
             &self,
-            ctx: tarpc::context::Context,
+            ctx: RpcContext,
             req: InstallSnapshotRequest,
         ) -> anyhow::Result<InstallSnapshotResponse> {
             let partitions = self.partitions.lock().await;
@@ -244,27 +315,27 @@ pub mod mock {
                 if let Some(client) = clients.get(&addr) {
                     Arc::clone(client)
                 } else {
-                    use tarpc::client;
-                    use tarpc::tokio_serde::formats::Bincode;
-                    let transport = tarpc::serde_transport::tcp::connect(
-                        addr,
-                        Bincode::default,
+                    let endpoint = tonic::transport::Endpoint::from_shared(
+                        format!("http://{}", addr),
                     )
-                    .await
                     .map_err(|e| {
+                        NetworkError::ConnectionFailed(format!(
+                            "Invalid endpoint {}: {}",
+                            addr, e
+                        ))
+                    })?;
+
+                    let channel = endpoint.connect().await.map_err(|e| {
                         NetworkError::ConnectionFailed(format!(
                             "Failed to connect to {}: {}",
                             addr, e
                         ))
                     })?;
 
-                    let client = RaftRpcClient::new(
-                        client::Config::default(),
-                        transport,
-                    )
-                    .spawn();
+                    let client =
+                        proto::raft_rpc_client::RaftRpcClient::new(channel);
 
-                    Arc::new(client)
+                    Arc::new(TonicRpcClient { inner: client })
                 }
             };
 

--- a/src/node/election.rs
+++ b/src/node/election.rs
@@ -228,7 +228,7 @@ where
         req: RequestVoteRequest,
         rpc_timeout: Duration,
     ) -> anyhow::Result<RequestVoteResponse> {
-        let ctx = crate::rpc::RpcContext::current()
+        let ctx = crate::rpc::RpcContext::background()
             .with_deadline(Instant::now() + rpc_timeout);
 
         client.request_vote(ctx, req.clone()).await.map_err(|e| {

--- a/src/node/election.rs
+++ b/src/node/election.rs
@@ -228,8 +228,8 @@ where
         req: RequestVoteRequest,
         rpc_timeout: Duration,
     ) -> anyhow::Result<RequestVoteResponse> {
-        let mut ctx = tarpc::context::Context::current();
-        ctx.deadline = Instant::now() + rpc_timeout;
+        let ctx = crate::rpc::RpcContext::current()
+            .with_deadline(Instant::now() + rpc_timeout);
 
         client.request_vote(ctx, req.clone()).await.map_err(|e| {
             tracing::warn!(

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -24,7 +24,7 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinSet;
 use tracing::Instrument;
 
-fn notify_heartbeat(
+pub(crate) fn notify_heartbeat(
     req_term: Term,
     leader_id: NodeId,
     current_term: Term,
@@ -35,7 +35,9 @@ fn notify_heartbeat(
     }
 }
 
-fn not_leader_response(leader_id: Option<NodeId>) -> CommandResponse {
+pub(crate) fn not_leader_response(
+    leader_id: Option<NodeId>,
+) -> CommandResponse {
     CommandResponse {
         success: false,
         leader_hint: leader_id,
@@ -317,29 +319,39 @@ where
         }
     }
 
-    /// Starts the Raft node and runs until error or shutdown.
-    /// Spawns three tasks: main loop, RPC handler, and RPC server.
     #[tracing::instrument(skip(self, servers), fields(port = port))]
     pub async fn run(
-        self,
+        mut self,
         port: u16,
         servers: Vec<SocketAddr>,
     ) -> anyhow::Result<()>
     where
         T: Default,
+        SM::Response: Clone + serde::Serialize,
     {
         use tracing::Instrument;
 
-        let (tx, rx) = mpsc::channel::<Command>(32);
+        self.setup(servers).await?;
+
+        let state = Arc::clone(&self.state);
+        let request_tracker = Arc::clone(&self.request_tracker);
+        let heartbeat_tx = self.c.heartbeat_tx.clone();
+        let client_request_tx = self.c.client_request_tx.clone();
+        let config = self.config.clone();
+
         let mut workers = JoinSet::new();
         workers.spawn(
-            self.run_with_handler(servers, rx)
-                .instrument(tracing::Span::current()),
+            crate::server::rpc_server(
+                state,
+                request_tracker,
+                heartbeat_tx,
+                client_request_tx,
+                config,
+                port,
+            )
+            .instrument(tracing::Span::current()),
         );
-        workers.spawn(
-            crate::server::rpc_server(tx, port)
-                .instrument(tracing::Span::current()),
-        );
+        workers.spawn(self.main(vec![]).instrument(tracing::Span::current()));
 
         if let Some(res) = workers.join_next().await {
             res??;

--- a/src/node/replication.rs
+++ b/src/node/replication.rs
@@ -366,7 +366,7 @@ where
         sent_up_to_index: LogIndex,
         rpc_timeout: Duration,
     ) -> anyhow::Result<(SocketAddr, ReplicationResponse)> {
-        let ctx = crate::rpc::RpcContext::current()
+        let ctx = crate::rpc::RpcContext::background()
             .with_deadline(Instant::now() + rpc_timeout);
         let res = client.append_entries(ctx, req.clone()).await?;
         Ok((
@@ -381,7 +381,7 @@ where
         req: crate::rpc::InstallSnapshotRequest,
         rpc_timeout: Duration,
     ) -> anyhow::Result<(SocketAddr, ReplicationResponse)> {
-        let ctx = crate::rpc::RpcContext::current()
+        let ctx = crate::rpc::RpcContext::background()
             .with_deadline(Instant::now() + rpc_timeout);
         let last_included_index = req.last_included_index;
         let res = client.install_snapshot(ctx, req).await?;
@@ -810,7 +810,7 @@ mod tests {
         };
 
         let result = client
-            .append_entries(RpcContext::current(), req.clone())
+            .append_entries(RpcContext::background(), req.clone())
             .await;
         assert!(
             result.is_ok(),
@@ -824,7 +824,7 @@ mod tests {
         .await;
 
         let result = client
-            .append_entries(RpcContext::current(), req.clone())
+            .append_entries(RpcContext::background(), req.clone())
             .await;
         assert!(
             result.is_err(),
@@ -843,7 +843,7 @@ mod tests {
         )
         .await;
 
-        let result = client.append_entries(RpcContext::current(), req).await;
+        let result = client.append_entries(RpcContext::background(), req).await;
         assert!(
             result.is_ok(),
             "Expected success after healing, got error: {:?}",

--- a/src/node/replication.rs
+++ b/src/node/replication.rs
@@ -359,7 +359,6 @@ where
         Ok(has_majority)
     }
 
-    /// Sends AppendEntries RPC to a single follower.
     async fn send_heartbeat(
         server: SocketAddr,
         client: Arc<dyn RaftRpcTrait>,
@@ -367,10 +366,8 @@ where
         sent_up_to_index: LogIndex,
         rpc_timeout: Duration,
     ) -> anyhow::Result<(SocketAddr, ReplicationResponse)> {
-        use crate::trace::TraceContextInjector;
-
-        let mut ctx = tarpc::context::Context::current().with_current_trace();
-        ctx.deadline = Instant::now() + rpc_timeout;
+        let ctx = crate::rpc::RpcContext::current()
+            .with_deadline(Instant::now() + rpc_timeout);
         let res = client.append_entries(ctx, req.clone()).await?;
         Ok((
             server,
@@ -378,15 +375,14 @@ where
         ))
     }
 
-    /// Sends InstallSnapshot RPC to a single follower.
     async fn send_install_snapshot(
         server: SocketAddr,
         client: Arc<dyn RaftRpcTrait>,
         req: crate::rpc::InstallSnapshotRequest,
         rpc_timeout: Duration,
     ) -> anyhow::Result<(SocketAddr, ReplicationResponse)> {
-        let mut ctx = tarpc::context::current();
-        ctx.deadline = Instant::now() + rpc_timeout;
+        let ctx = crate::rpc::RpcContext::current()
+            .with_deadline(Instant::now() + rpc_timeout);
         let last_included_index = req.last_included_index;
         let res = client.install_snapshot(ctx, req).await?;
         Ok((
@@ -750,7 +746,7 @@ mod tests {
         impl RaftRpcTrait for MockRpcClient {
             async fn append_entries(
                 &self,
-                _ctx: tarpc::context::Context,
+                _ctx: RpcContext,
                 _req: AppendEntriesRequest,
             ) -> anyhow::Result<AppendEntriesResponse> {
                 Ok(AppendEntriesResponse {
@@ -761,7 +757,7 @@ mod tests {
 
             async fn request_vote(
                 &self,
-                _ctx: tarpc::context::Context,
+                _ctx: RpcContext,
                 _req: RequestVoteRequest,
             ) -> anyhow::Result<RequestVoteResponse> {
                 Ok(RequestVoteResponse {
@@ -772,7 +768,7 @@ mod tests {
 
             async fn client_request(
                 &self,
-                _ctx: tarpc::context::Context,
+                _ctx: RpcContext,
                 _req: CommandRequest,
             ) -> anyhow::Result<CommandResponse> {
                 Ok(CommandResponse {
@@ -785,7 +781,7 @@ mod tests {
 
             async fn install_snapshot(
                 &self,
-                _ctx: tarpc::context::Context,
+                _ctx: RpcContext,
                 _req: InstallSnapshotRequest,
             ) -> anyhow::Result<InstallSnapshotResponse> {
                 Ok(InstallSnapshotResponse { term: Term::new(1) })
@@ -814,7 +810,7 @@ mod tests {
         };
 
         let result = client
-            .append_entries(tarpc::context::current(), req.clone())
+            .append_entries(RpcContext::current(), req.clone())
             .await;
         assert!(
             result.is_ok(),
@@ -828,7 +824,7 @@ mod tests {
         .await;
 
         let result = client
-            .append_entries(tarpc::context::current(), req.clone())
+            .append_entries(RpcContext::current(), req.clone())
             .await;
         assert!(
             result.is_err(),
@@ -847,8 +843,7 @@ mod tests {
         )
         .await;
 
-        let result =
-            client.append_entries(tarpc::context::current(), req).await;
+        let result = client.append_entries(RpcContext::current(), req).await;
         assert!(
             result.is_ok(),
             "Expected success after healing, got error: {:?}",

--- a/src/node/replication.rs
+++ b/src/node/replication.rs
@@ -359,6 +359,7 @@ where
         Ok(has_majority)
     }
 
+    /// Sends AppendEntries RPC to a single follower.
     async fn send_heartbeat(
         server: SocketAddr,
         client: Arc<dyn RaftRpcTrait>,
@@ -375,6 +376,7 @@ where
         ))
     }
 
+    /// Sends InstallSnapshot RPC to a single follower.
     async fn send_install_snapshot(
         server: SocketAddr,
         client: Arc<dyn RaftRpcTrait>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -129,6 +129,8 @@ pub struct InstallSnapshotResponse {
     pub term: Term,
 }
 
+/// Trait for Raft RPC client abstraction.
+/// This is dyn-compatible, unlike framework-specific generated traits.
 #[async_trait::async_trait]
 pub trait RaftRpcTrait: Send + Sync {
     async fn append_entries(

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -9,7 +9,7 @@ pub struct RpcContext {
 }
 
 impl RpcContext {
-    pub fn current() -> Self {
+    pub fn background() -> Self {
         Self { deadline: None }
     }
 
@@ -154,6 +154,16 @@ pub trait RaftRpcTrait: Send + Sync {
         ctx: RpcContext,
         req: InstallSnapshotRequest,
     ) -> anyhow::Result<InstallSnapshotResponse>;
+}
+
+impl RpcContext {
+    pub fn into_tonic_request<T>(self, message: T) -> tonic::Request<T> {
+        let mut req = tonic::Request::new(message);
+        if let Some(timeout) = self.timeout() {
+            req.set_timeout(timeout);
+        }
+        req
+    }
 }
 
 pub mod proto {
@@ -402,7 +412,7 @@ mod tests {
 
     #[test]
     fn rpc_context_with_timeout() {
-        let ctx = RpcContext::current().with_timeout(Duration::from_secs(5));
+        let ctx = RpcContext::background().with_timeout(Duration::from_secs(5));
         assert!(ctx.deadline.is_some());
         let timeout = ctx.timeout().unwrap();
         assert!(timeout <= Duration::from_secs(5));
@@ -411,7 +421,7 @@ mod tests {
 
     #[test]
     fn rpc_context_no_deadline() {
-        let ctx = RpcContext::current();
+        let ctx = RpcContext::background();
         assert!(ctx.deadline.is_none());
         assert!(ctx.timeout().is_none());
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,9 +1,34 @@
 use crate::types::{LogIndex, NodeId, Term};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tarpc::serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct RpcContext {
+    pub deadline: Option<Instant>,
+}
+
+impl RpcContext {
+    pub fn current() -> Self {
+        Self { deadline: None }
+    }
+
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
+    pub fn with_timeout(self, timeout: Duration) -> Self {
+        self.with_deadline(Instant::now() + timeout)
+    }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        self.deadline
+            .map(|d| d.saturating_duration_since(Instant::now()))
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct LogEntry {
     pub term: Term,
     #[serde(with = "arc_bytes")]
@@ -34,7 +59,6 @@ mod arc_bytes {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct AppendEntriesRequest {
     pub term: Term,
     pub leader_id: NodeId,
@@ -45,14 +69,12 @@ pub struct AppendEntriesRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct AppendEntriesResponse {
     pub term: Term,
     pub success: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct RequestVoteRequest {
     pub term: Term,
     pub candidate_id: NodeId,
@@ -61,14 +83,12 @@ pub struct RequestVoteRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct RequestVoteResponse {
     pub term: Term,
     pub vote_granted: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct CommandRequest {
     pub command: Vec<u8>,
 }
@@ -76,7 +96,6 @@ pub struct CommandRequest {
 #[derive(
     Serialize, Deserialize, Debug, Clone, PartialEq, Eq, thiserror::Error,
 )]
-#[serde(crate = "tarpc::serde")]
 pub enum CommandError {
     #[error("Not the leader")]
     NotLeader,
@@ -89,7 +108,6 @@ pub enum CommandError {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct CommandResponse {
     pub success: bool,
     pub leader_hint: Option<NodeId>,
@@ -98,7 +116,6 @@ pub struct CommandResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct InstallSnapshotRequest {
     pub term: Term,
     pub leader_id: NodeId,
@@ -108,95 +125,442 @@ pub struct InstallSnapshotRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(crate = "tarpc::serde")]
 pub struct InstallSnapshotResponse {
     pub term: Term,
 }
 
-#[tarpc::service]
-pub trait RaftRpc {
-    async fn append_entries(req: AppendEntriesRequest)
-    -> AppendEntriesResponse;
-    async fn request_vote(req: RequestVoteRequest) -> RequestVoteResponse;
-    async fn client_request(req: CommandRequest) -> CommandResponse;
-    async fn install_snapshot(
-        req: InstallSnapshotRequest,
-    ) -> InstallSnapshotResponse;
-}
-
-/// Trait for Raft RPC client abstraction.
-/// This is dyn-compatible, unlike the tarpc-generated RaftRpc trait.
 #[async_trait::async_trait]
 pub trait RaftRpcTrait: Send + Sync {
     async fn append_entries(
         &self,
-        ctx: tarpc::context::Context,
+        ctx: RpcContext,
         req: AppendEntriesRequest,
     ) -> anyhow::Result<AppendEntriesResponse>;
 
     async fn request_vote(
         &self,
-        ctx: tarpc::context::Context,
+        ctx: RpcContext,
         req: RequestVoteRequest,
     ) -> anyhow::Result<RequestVoteResponse>;
 
     async fn client_request(
         &self,
-        ctx: tarpc::context::Context,
+        ctx: RpcContext,
         req: CommandRequest,
     ) -> anyhow::Result<CommandResponse>;
 
     async fn install_snapshot(
         &self,
-        ctx: tarpc::context::Context,
+        ctx: RpcContext,
         req: InstallSnapshotRequest,
     ) -> anyhow::Result<InstallSnapshotResponse>;
 }
 
-/// Implement RaftRpcTrait for RaftRpcClient (tarpc-generated client)
-#[async_trait::async_trait]
-impl RaftRpcTrait for RaftRpcClient {
-    async fn append_entries(
-        &self,
-        ctx: tarpc::context::Context,
-        req: AppendEntriesRequest,
-    ) -> anyhow::Result<AppendEntriesResponse> {
-        self.clone()
-            .append_entries(ctx, req)
-            .await
-            .map_err(Into::into)
+pub mod proto {
+    tonic::include_proto!("raft");
+}
+
+impl From<&LogEntry> for proto::LogEntry {
+    fn from(e: &LogEntry) -> Self {
+        Self {
+            term: e.term.as_u32(),
+            command: e.command.to_vec(),
+        }
+    }
+}
+
+impl From<proto::LogEntry> for LogEntry {
+    fn from(e: proto::LogEntry) -> Self {
+        Self {
+            term: Term::new(e.term),
+            command: Arc::from(e.command.into_boxed_slice()),
+        }
+    }
+}
+
+impl From<&AppendEntriesRequest> for proto::AppendEntriesRequest {
+    fn from(r: &AppendEntriesRequest) -> Self {
+        Self {
+            term: r.term.as_u32(),
+            leader_id: r.leader_id.as_u32(),
+            prev_log_index: r.prev_log_index.as_u32(),
+            prev_log_term: r.prev_log_term.as_u32(),
+            entries: r.entries.iter().map(Into::into).collect(),
+            leader_commit: r.leader_commit.as_u32(),
+        }
+    }
+}
+
+impl From<proto::AppendEntriesRequest> for AppendEntriesRequest {
+    fn from(r: proto::AppendEntriesRequest) -> Self {
+        Self {
+            term: Term::new(r.term),
+            leader_id: NodeId::new(r.leader_id),
+            prev_log_index: LogIndex::new(r.prev_log_index),
+            prev_log_term: Term::new(r.prev_log_term),
+            entries: r.entries.into_iter().map(Into::into).collect(),
+            leader_commit: LogIndex::new(r.leader_commit),
+        }
+    }
+}
+
+impl From<&AppendEntriesResponse> for proto::AppendEntriesResponse {
+    fn from(r: &AppendEntriesResponse) -> Self {
+        Self {
+            term: r.term.as_u32(),
+            success: r.success,
+        }
+    }
+}
+
+impl From<proto::AppendEntriesResponse> for AppendEntriesResponse {
+    fn from(r: proto::AppendEntriesResponse) -> Self {
+        Self {
+            term: Term::new(r.term),
+            success: r.success,
+        }
+    }
+}
+
+impl From<&RequestVoteRequest> for proto::RequestVoteRequest {
+    fn from(r: &RequestVoteRequest) -> Self {
+        Self {
+            term: r.term.as_u32(),
+            candidate_id: r.candidate_id.as_u32(),
+            last_log_index: r.last_log_index.as_u32(),
+            last_log_term: r.last_log_term.as_u32(),
+        }
+    }
+}
+
+impl From<proto::RequestVoteRequest> for RequestVoteRequest {
+    fn from(r: proto::RequestVoteRequest) -> Self {
+        Self {
+            term: Term::new(r.term),
+            candidate_id: NodeId::new(r.candidate_id),
+            last_log_index: LogIndex::new(r.last_log_index),
+            last_log_term: Term::new(r.last_log_term),
+        }
+    }
+}
+
+impl From<&RequestVoteResponse> for proto::RequestVoteResponse {
+    fn from(r: &RequestVoteResponse) -> Self {
+        Self {
+            term: r.term.as_u32(),
+            vote_granted: r.vote_granted,
+        }
+    }
+}
+
+impl From<proto::RequestVoteResponse> for RequestVoteResponse {
+    fn from(r: proto::RequestVoteResponse) -> Self {
+        Self {
+            term: Term::new(r.term),
+            vote_granted: r.vote_granted,
+        }
+    }
+}
+
+impl From<&CommandRequest> for proto::CommandRequest {
+    fn from(r: &CommandRequest) -> Self {
+        Self {
+            command: r.command.clone(),
+        }
+    }
+}
+
+impl From<proto::CommandRequest> for CommandRequest {
+    fn from(r: proto::CommandRequest) -> Self {
+        Self { command: r.command }
+    }
+}
+
+impl From<&CommandResponse> for proto::CommandResponse {
+    fn from(r: &CommandResponse) -> Self {
+        let (has_error, error_kind, error_message) = match &r.error {
+            Some(e) => {
+                let (kind, msg) = match e {
+                    CommandError::NotLeader => (
+                        proto::CommandErrorKind::NotLeader as i32,
+                        String::new(),
+                    ),
+                    CommandError::NoopNotCommitted => (
+                        proto::CommandErrorKind::NoopNotCommitted as i32,
+                        String::new(),
+                    ),
+                    CommandError::ReplicationFailed => (
+                        proto::CommandErrorKind::ReplicationFailed as i32,
+                        String::new(),
+                    ),
+                    CommandError::Other(s) => {
+                        (proto::CommandErrorKind::Other as i32, s.clone())
+                    }
+                };
+                (true, kind, msg)
+            }
+            None => (false, 0, String::new()),
+        };
+
+        Self {
+            success: r.success,
+            has_leader_hint: r.leader_hint.is_some(),
+            leader_hint: r.leader_hint.map(|id| id.as_u32()).unwrap_or(0),
+            has_data: r.data.is_some(),
+            data: r.data.clone().unwrap_or_default(),
+            has_error,
+            error_kind,
+            error_message,
+        }
+    }
+}
+
+impl From<proto::CommandResponse> for CommandResponse {
+    fn from(r: proto::CommandResponse) -> Self {
+        let leader_hint = if r.has_leader_hint {
+            Some(NodeId::new(r.leader_hint))
+        } else {
+            None
+        };
+
+        let data = if r.has_data { Some(r.data) } else { None };
+
+        let error = if r.has_error {
+            let kind = proto::CommandErrorKind::try_from(r.error_kind)
+                .unwrap_or(proto::CommandErrorKind::Unspecified);
+            Some(match kind {
+                proto::CommandErrorKind::NotLeader => CommandError::NotLeader,
+                proto::CommandErrorKind::NoopNotCommitted => {
+                    CommandError::NoopNotCommitted
+                }
+                proto::CommandErrorKind::ReplicationFailed => {
+                    CommandError::ReplicationFailed
+                }
+                proto::CommandErrorKind::Other => {
+                    CommandError::Other(r.error_message)
+                }
+                proto::CommandErrorKind::Unspecified => {
+                    CommandError::Other(r.error_message)
+                }
+            })
+        } else {
+            None
+        };
+
+        Self {
+            success: r.success,
+            leader_hint,
+            data,
+            error,
+        }
+    }
+}
+
+impl From<&InstallSnapshotRequest> for proto::InstallSnapshotRequest {
+    fn from(r: &InstallSnapshotRequest) -> Self {
+        Self {
+            term: r.term.as_u32(),
+            leader_id: r.leader_id.as_u32(),
+            last_included_index: r.last_included_index.as_u32(),
+            last_included_term: r.last_included_term.as_u32(),
+            data: r.data.clone(),
+        }
+    }
+}
+
+impl From<proto::InstallSnapshotRequest> for InstallSnapshotRequest {
+    fn from(r: proto::InstallSnapshotRequest) -> Self {
+        Self {
+            term: Term::new(r.term),
+            leader_id: NodeId::new(r.leader_id),
+            last_included_index: LogIndex::new(r.last_included_index),
+            last_included_term: Term::new(r.last_included_term),
+            data: r.data,
+        }
+    }
+}
+
+impl From<&InstallSnapshotResponse> for proto::InstallSnapshotResponse {
+    fn from(r: &InstallSnapshotResponse) -> Self {
+        Self {
+            term: r.term.as_u32(),
+        }
+    }
+}
+
+impl From<proto::InstallSnapshotResponse> for InstallSnapshotResponse {
+    fn from(r: proto::InstallSnapshotResponse) -> Self {
+        Self {
+            term: Term::new(r.term),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_context_with_timeout() {
+        let ctx = RpcContext::current().with_timeout(Duration::from_secs(5));
+        assert!(ctx.deadline.is_some());
+        let timeout = ctx.timeout().unwrap();
+        assert!(timeout <= Duration::from_secs(5));
+        assert!(timeout > Duration::from_secs(4));
     }
 
-    async fn request_vote(
-        &self,
-        ctx: tarpc::context::Context,
-        req: RequestVoteRequest,
-    ) -> anyhow::Result<RequestVoteResponse> {
-        self.clone()
-            .request_vote(ctx, req)
-            .await
-            .map_err(Into::into)
+    #[test]
+    fn rpc_context_no_deadline() {
+        let ctx = RpcContext::current();
+        assert!(ctx.deadline.is_none());
+        assert!(ctx.timeout().is_none());
     }
 
-    async fn client_request(
-        &self,
-        ctx: tarpc::context::Context,
-        req: CommandRequest,
-    ) -> anyhow::Result<CommandResponse> {
-        self.clone()
-            .client_request(ctx, req)
-            .await
-            .map_err(Into::into)
+    #[test]
+    fn append_entries_request_roundtrip() {
+        let req = AppendEntriesRequest {
+            term: Term::new(5),
+            leader_id: NodeId::new(1),
+            prev_log_index: LogIndex::new(10),
+            prev_log_term: Term::new(4),
+            entries: vec![LogEntry {
+                term: Term::new(5),
+                command: Arc::from(vec![1, 2, 3].into_boxed_slice()),
+            }],
+            leader_commit: LogIndex::new(9),
+        };
+
+        let proto_req: proto::AppendEntriesRequest = (&req).into();
+        let back: AppendEntriesRequest = proto_req.into();
+
+        assert_eq!(back.term, req.term);
+        assert_eq!(back.leader_id, req.leader_id);
+        assert_eq!(back.prev_log_index, req.prev_log_index);
+        assert_eq!(back.prev_log_term, req.prev_log_term);
+        assert_eq!(back.entries.len(), 1);
+        assert_eq!(back.entries[0].term, Term::new(5));
+        assert_eq!(&*back.entries[0].command, &[1, 2, 3]);
+        assert_eq!(back.leader_commit, req.leader_commit);
     }
 
-    async fn install_snapshot(
-        &self,
-        ctx: tarpc::context::Context,
-        req: InstallSnapshotRequest,
-    ) -> anyhow::Result<InstallSnapshotResponse> {
-        self.clone()
-            .install_snapshot(ctx, req)
-            .await
-            .map_err(Into::into)
+    #[test]
+    fn append_entries_response_roundtrip() {
+        let resp = AppendEntriesResponse {
+            term: Term::new(5),
+            success: true,
+        };
+        let proto_resp: proto::AppendEntriesResponse = (&resp).into();
+        let back: AppendEntriesResponse = proto_resp.into();
+        assert_eq!(back.term, resp.term);
+        assert_eq!(back.success, resp.success);
+    }
+
+    #[test]
+    fn request_vote_roundtrip() {
+        let req = RequestVoteRequest {
+            term: Term::new(3),
+            candidate_id: NodeId::new(2),
+            last_log_index: LogIndex::new(5),
+            last_log_term: Term::new(2),
+        };
+        let proto_req: proto::RequestVoteRequest = (&req).into();
+        let back: RequestVoteRequest = proto_req.into();
+        assert_eq!(back.term, req.term);
+        assert_eq!(back.candidate_id, req.candidate_id);
+        assert_eq!(back.last_log_index, req.last_log_index);
+        assert_eq!(back.last_log_term, req.last_log_term);
+    }
+
+    #[test]
+    fn request_vote_response_roundtrip() {
+        let resp = RequestVoteResponse {
+            term: Term::new(3),
+            vote_granted: true,
+        };
+        let proto_resp: proto::RequestVoteResponse = (&resp).into();
+        let back: RequestVoteResponse = proto_resp.into();
+        assert_eq!(back.term, resp.term);
+        assert_eq!(back.vote_granted, resp.vote_granted);
+    }
+
+    #[test]
+    fn command_response_roundtrip_with_all_fields() {
+        let resp = CommandResponse {
+            success: true,
+            leader_hint: Some(NodeId::new(42)),
+            data: Some(vec![10, 20]),
+            error: Some(CommandError::Other("test error".to_string())),
+        };
+        let proto_resp: proto::CommandResponse = (&resp).into();
+        let back: CommandResponse = proto_resp.into();
+        assert!(back.success);
+        assert_eq!(back.leader_hint, Some(NodeId::new(42)));
+        assert_eq!(back.data, Some(vec![10, 20]));
+        assert_eq!(
+            back.error,
+            Some(CommandError::Other("test error".to_string()))
+        );
+    }
+
+    #[test]
+    fn command_response_roundtrip_no_optional_fields() {
+        let resp = CommandResponse {
+            success: false,
+            leader_hint: None,
+            data: None,
+            error: None,
+        };
+        let proto_resp: proto::CommandResponse = (&resp).into();
+        let back: CommandResponse = proto_resp.into();
+        assert!(!back.success);
+        assert!(back.leader_hint.is_none());
+        assert!(back.data.is_none());
+        assert!(back.error.is_none());
+    }
+
+    #[test]
+    fn command_error_variants_roundtrip() {
+        for error in [
+            CommandError::NotLeader,
+            CommandError::NoopNotCommitted,
+            CommandError::ReplicationFailed,
+            CommandError::Other("custom".to_string()),
+        ] {
+            let resp = CommandResponse {
+                success: false,
+                leader_hint: None,
+                data: None,
+                error: Some(error.clone()),
+            };
+            let proto_resp: proto::CommandResponse = (&resp).into();
+            let back: CommandResponse = proto_resp.into();
+            assert_eq!(back.error, Some(error));
+        }
+    }
+
+    #[test]
+    fn install_snapshot_roundtrip() {
+        let req = InstallSnapshotRequest {
+            term: Term::new(7),
+            leader_id: NodeId::new(3),
+            last_included_index: LogIndex::new(100),
+            last_included_term: Term::new(6),
+            data: vec![42; 256],
+        };
+        let proto_req: proto::InstallSnapshotRequest = (&req).into();
+        let back: InstallSnapshotRequest = proto_req.into();
+        assert_eq!(back.term, req.term);
+        assert_eq!(back.leader_id, req.leader_id);
+        assert_eq!(back.last_included_index, req.last_included_index);
+        assert_eq!(back.last_included_term, req.last_included_term);
+        assert_eq!(back.data, req.data);
+    }
+
+    #[test]
+    fn install_snapshot_response_roundtrip() {
+        let resp = InstallSnapshotResponse { term: Term::new(7) };
+        let proto_resp: proto::InstallSnapshotResponse = (&resp).into();
+        let back: InstallSnapshotResponse = proto_resp.into();
+        assert_eq!(back.term, resp.term);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,14 +7,10 @@ use crate::rpc::*;
 use crate::statemachine::StateMachine;
 use crate::types::{NodeId, Term};
 use anyhow::Context;
-use futures::{future, prelude::*};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::SocketAddr;
 use std::sync::Arc;
-use tarpc::{
-    server::{self, Channel, incoming::Incoming},
-    tokio_serde::formats::Bincode,
-};
 use tokio::sync::{Mutex, mpsc, oneshot};
+use tonic::{Request, Response, Status, transport::Server};
 
 pub async fn rpc_server<T, SM>(
     state: Arc<Mutex<RaftState<T, SM>>>,
@@ -38,39 +34,24 @@ where
     SM: StateMachine<Command = T> + std::fmt::Debug + 'static,
     SM::Response: Clone + serde::Serialize,
 {
-    let addr = (IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let mut listener =
-        tarpc::serde_transport::tcp::listen(&addr, Bincode::default)
-            .await
-            .context("failed to start RPC server")?;
-    listener.config_mut().max_frame_length(usize::MAX);
-    listener
-        .filter_map(|r| future::ready(r.ok()))
-        .map(server::BaseChannel::with_defaults)
-        .max_channels_per_key(10, |t| {
-            t.transport()
-                .peer_addr()
-                .map(|a| a.ip())
-                .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-        })
-        .for_each_concurrent(10, |channel| {
-            let server = RaftServer {
-                state: Arc::clone(&state),
-                request_tracker: Arc::clone(&request_tracker),
-                heartbeat_tx: heartbeat_tx.clone(),
-                client_request_tx: client_request_tx.clone(),
-                config: config.clone(),
-            };
-            async {
-                channel
-                    .execute(server.serve())
-                    .for_each(|response| async move {
-                        tokio::spawn(response);
-                    })
-                    .await
-            }
-        })
-        .await;
+    let addr: SocketAddr = format!("0.0.0.0:{}", port)
+        .parse()
+        .context("failed to parse server address")?;
+
+    let server = RaftServer {
+        state,
+        request_tracker,
+        heartbeat_tx,
+        client_request_tx,
+        config,
+    };
+
+    Server::builder()
+        .add_service(proto::raft_rpc_server::RaftRpcServer::new(server))
+        .serve(addr)
+        .await
+        .context("failed to serve gRPC server")?;
+
     Ok(())
 }
 
@@ -99,7 +80,8 @@ impl<T: Send + Sync, SM: StateMachine<Command = T>> Clone
     }
 }
 
-impl<T, SM> RaftRpc for RaftServer<T, SM>
+#[tonic::async_trait]
+impl<T, SM> proto::raft_rpc_server::RaftRpc for RaftServer<T, SM>
 where
     T: Send
         + Sync
@@ -111,12 +93,14 @@ where
     SM: StateMachine<Command = T> + std::fmt::Debug + 'static,
     SM::Response: Clone + serde::Serialize,
 {
-    #[tracing::instrument(skip(self, _ctx), fields(term = %req.term, leader_id = %req.leader_id, entries_count = req.entries.len()))]
+    #[tracing::instrument(skip(self, request), fields(term = %Term::new(request.get_ref().term), leader_id = %NodeId::new(request.get_ref().leader_id), entries_count = request.get_ref().entries.len()))]
     async fn append_entries(
-        self,
-        _ctx: tarpc::context::Context,
-        req: AppendEntriesRequest,
-    ) -> AppendEntriesResponse {
+        &self,
+        request: Request<proto::AppendEntriesRequest>,
+    ) -> Result<Response<proto::AppendEntriesResponse>, Status> {
+        let proto_req = request.into_inner();
+        let req: AppendEntriesRequest = proto_req.into();
+
         let current_term = self.state.lock().await.persistent.current_term;
         let resp = handlers::handle_append_entries(
             &req,
@@ -137,51 +121,68 @@ where
             current_term,
             &self.heartbeat_tx,
         );
-        resp
+
+        let proto_resp: proto::AppendEntriesResponse = (&resp).into();
+        Ok(Response::new(proto_resp))
     }
 
-    #[tracing::instrument(skip(self, _ctx), fields(term = %req.term, candidate_id = %req.candidate_id))]
+    #[tracing::instrument(skip(self, request), fields(term = %Term::new(request.get_ref().term), candidate_id = %NodeId::new(request.get_ref().candidate_id)))]
     async fn request_vote(
-        self,
-        _ctx: tarpc::context::Context,
-        req: RequestVoteRequest,
-    ) -> RequestVoteResponse {
-        handlers::handle_request_vote(&req, Arc::clone(&self.state)).await
+        &self,
+        request: Request<proto::RequestVoteRequest>,
+    ) -> Result<Response<proto::RequestVoteResponse>, Status> {
+        let proto_req = request.into_inner();
+        let req: RequestVoteRequest = proto_req.into();
+
+        let resp =
+            handlers::handle_request_vote(&req, Arc::clone(&self.state)).await;
+
+        let proto_resp: proto::RequestVoteResponse = (&resp).into();
+        Ok(Response::new(proto_resp))
     }
 
-    #[tracing::instrument(skip(self, _ctx, req))]
+    #[tracing::instrument(skip(self, request))]
     async fn client_request(
-        self,
-        _ctx: tarpc::context::Context,
-        req: CommandRequest,
-    ) -> CommandResponse {
+        &self,
+        request: Request<proto::CommandRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        let proto_req = request.into_inner();
+        let req: CommandRequest = proto_req.into();
+
         let (is_leader, leader_id) = {
             let state = self.state.lock().await;
             (state.role().is_leader(), state.leader_id)
         };
 
         if !is_leader {
-            return not_leader_response(leader_id);
+            let resp = not_leader_response(leader_id);
+            let proto_resp: proto::CommandResponse = (&resp).into();
+            return Ok(Response::new(proto_resp));
         }
 
         let (resp_tx, resp_rx) = oneshot::channel();
         let _ = self.client_request_tx.send((req, resp_tx));
-        resp_rx.await.unwrap_or(CommandResponse {
+        let resp = resp_rx.await.unwrap_or(CommandResponse {
             success: false,
             leader_hint: None,
             data: None,
             error: Some(crate::rpc::CommandError::Other(
                 "Failed to process client request".to_string(),
             )),
-        })
+        });
+
+        let proto_resp: proto::CommandResponse = (&resp).into();
+        Ok(Response::new(proto_resp))
     }
 
-    #[tracing::instrument(skip(self, _ctx), fields(term = %req.term, leader_id = %req.leader_id, last_included_index = %req.last_included_index))]
+    #[tracing::instrument(skip(self, request), fields(term = %Term::new(request.get_ref().term), leader_id = %NodeId::new(request.get_ref().leader_id), last_included_index = %crate::types::LogIndex::new(request.get_ref().last_included_index)))]
     async fn install_snapshot(
-        self,
-        _ctx: tarpc::context::Context,
-        req: InstallSnapshotRequest,
-    ) -> InstallSnapshotResponse {
+        &self,
+        request: Request<proto::InstallSnapshotRequest>,
+    ) -> Result<Response<proto::InstallSnapshotResponse>, Status> {
+        let proto_req = request.into_inner();
+        let req: InstallSnapshotRequest = proto_req.into();
+
         let current_term = self.state.lock().await.persistent.current_term;
         let resp = handlers::handle_install_snapshot(
             &req,
@@ -198,6 +199,8 @@ where
             current_term,
             &self.heartbeat_tx,
         );
-        resp
+
+        let proto_resp: proto::InstallSnapshotResponse = (&resp).into();
+        Ok(Response::new(proto_resp))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,30 +1,46 @@
-//! RPC server setup and RaftRpc trait implementation.
-//!
-//! This module provides:
-//! - RPC server based on tarpc with TCP transport
-//! - RaftServer that converts RPC requests into Command enum and sends via channel
-
-use crate::node::Command;
+use crate::config::Config;
+use crate::node::handlers;
+use crate::node::{not_leader_response, notify_heartbeat};
+use crate::raft::RaftState;
+use crate::request_tracker::RequestTracker;
 use crate::rpc::*;
-use crate::types::Term;
+use crate::statemachine::StateMachine;
+use crate::types::{NodeId, Term};
 use anyhow::Context;
 use futures::{future, prelude::*};
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
 use tarpc::{
     server::{self, Channel, incoming::Incoming},
-    tokio_serde::formats::Json,
+    tokio_serde::formats::Bincode,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
-/// Starts the RPC server on the specified port.
-/// Listens for incoming tarpc connections and dispatches to RaftServer handlers.
-pub async fn rpc_server(
-    tx: mpsc::Sender<Command>,
+pub async fn rpc_server<T, SM>(
+    state: Arc<Mutex<RaftState<T, SM>>>,
+    request_tracker: Arc<Mutex<RequestTracker<SM::Response>>>,
+    heartbeat_tx: mpsc::UnboundedSender<(Term, NodeId)>,
+    client_request_tx: mpsc::UnboundedSender<(
+        CommandRequest,
+        oneshot::Sender<CommandResponse>,
+    )>,
+    config: Config,
     port: u16,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    T: Send
+        + Sync
+        + Clone
+        + std::fmt::Debug
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + 'static,
+    SM: StateMachine<Command = T> + std::fmt::Debug + 'static,
+    SM::Response: Clone + serde::Serialize,
+{
     let addr = (IpAddr::V4(Ipv4Addr::LOCALHOST), port);
     let mut listener =
-        tarpc::serde_transport::tcp::listen(&addr, Json::default)
+        tarpc::serde_transport::tcp::listen(&addr, Bincode::default)
             .await
             .context("failed to start RPC server")?;
     listener.config_mut().max_frame_length(usize::MAX);
@@ -37,42 +53,91 @@ pub async fn rpc_server(
                 .map(|a| a.ip())
                 .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
         })
-        .for_each_concurrent(10, |channel| async {
-            let server = RaftServer { tx: tx.clone() };
-            channel
-                .execute(server.serve())
-                .for_each(|response| async move {
-                    tokio::spawn(response);
-                })
-                .await
+        .for_each_concurrent(10, |channel| {
+            let server = RaftServer {
+                state: Arc::clone(&state),
+                request_tracker: Arc::clone(&request_tracker),
+                heartbeat_tx: heartbeat_tx.clone(),
+                client_request_tx: client_request_tx.clone(),
+                config: config.clone(),
+            };
+            async {
+                channel
+                    .execute(server.serve())
+                    .for_each(|response| async move {
+                        tokio::spawn(response);
+                    })
+                    .await
+            }
         })
         .await;
     Ok(())
 }
 
-/// RPC server implementation that forwards requests to the node via channels.
-#[derive(Clone)]
-struct RaftServer {
-    tx: mpsc::Sender<Command>,
+struct RaftServer<T: Send + Sync, SM: StateMachine<Command = T>> {
+    state: Arc<Mutex<RaftState<T, SM>>>,
+    request_tracker: Arc<Mutex<RequestTracker<SM::Response>>>,
+    heartbeat_tx: mpsc::UnboundedSender<(Term, NodeId)>,
+    client_request_tx: mpsc::UnboundedSender<(
+        CommandRequest,
+        oneshot::Sender<CommandResponse>,
+    )>,
+    config: Config,
 }
 
-impl RaftRpc for RaftServer {
+impl<T: Send + Sync, SM: StateMachine<Command = T>> Clone
+    for RaftServer<T, SM>
+{
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            request_tracker: Arc::clone(&self.request_tracker),
+            heartbeat_tx: self.heartbeat_tx.clone(),
+            client_request_tx: self.client_request_tx.clone(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+impl<T, SM> RaftRpc for RaftServer<T, SM>
+where
+    T: Send
+        + Sync
+        + Clone
+        + std::fmt::Debug
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + 'static,
+    SM: StateMachine<Command = T> + std::fmt::Debug + 'static,
+    SM::Response: Clone + serde::Serialize,
+{
     #[tracing::instrument(skip(self, _ctx), fields(term = %req.term, leader_id = %req.leader_id, entries_count = req.entries.len()))]
     async fn append_entries(
         self,
         _ctx: tarpc::context::Context,
         req: AppendEntriesRequest,
     ) -> AppendEntriesResponse {
-        let (resp_tx, resp_rx) = oneshot::channel();
-        let span = tracing::Span::current();
-        let _ = self
-            .tx
-            .send(Command::AppendEntries(req, resp_tx, span))
-            .await;
-        resp_rx.await.unwrap_or(AppendEntriesResponse {
-            term: Term::new(0),
-            success: false,
-        })
+        let current_term = self.state.lock().await.persistent.current_term;
+        let resp = handlers::handle_append_entries(
+            &req,
+            Arc::clone(&self.state),
+            Some(Arc::clone(&self.request_tracker)),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(error=?e, "Failed to handle AppendEntries");
+            AppendEntriesResponse {
+                term: Term::new(0),
+                success: false,
+            }
+        });
+        notify_heartbeat(
+            req.term,
+            req.leader_id,
+            current_term,
+            &self.heartbeat_tx,
+        );
+        resp
     }
 
     #[tracing::instrument(skip(self, _ctx), fields(term = %req.term, candidate_id = %req.candidate_id))]
@@ -81,13 +146,7 @@ impl RaftRpc for RaftServer {
         _ctx: tarpc::context::Context,
         req: RequestVoteRequest,
     ) -> RequestVoteResponse {
-        let (resp_tx, resp_rx) = oneshot::channel();
-        let span = tracing::Span::current();
-        let _ = self.tx.send(Command::RequestVote(req, resp_tx, span)).await;
-        resp_rx.await.unwrap_or(RequestVoteResponse {
-            term: Term::new(0),
-            vote_granted: false,
-        })
+        handlers::handle_request_vote(&req, Arc::clone(&self.state)).await
     }
 
     #[tracing::instrument(skip(self, _ctx, req))]
@@ -96,12 +155,17 @@ impl RaftRpc for RaftServer {
         _ctx: tarpc::context::Context,
         req: CommandRequest,
     ) -> CommandResponse {
+        let (is_leader, leader_id) = {
+            let state = self.state.lock().await;
+            (state.role().is_leader(), state.leader_id)
+        };
+
+        if !is_leader {
+            return not_leader_response(leader_id);
+        }
+
         let (resp_tx, resp_rx) = oneshot::channel();
-        let span = tracing::Span::current();
-        let _ = self
-            .tx
-            .send(Command::ClientRequest(req, resp_tx, span))
-            .await;
+        let _ = self.client_request_tx.send((req, resp_tx));
         resp_rx.await.unwrap_or(CommandResponse {
             success: false,
             leader_hint: None,
@@ -118,14 +182,22 @@ impl RaftRpc for RaftServer {
         _ctx: tarpc::context::Context,
         req: InstallSnapshotRequest,
     ) -> InstallSnapshotResponse {
-        let (resp_tx, resp_rx) = oneshot::channel();
-        let span = tracing::Span::current();
-        let _ = self
-            .tx
-            .send(Command::InstallSnapshot(req, resp_tx, span))
-            .await;
-        resp_rx
-            .await
-            .unwrap_or(InstallSnapshotResponse { term: Term::new(0) })
+        let current_term = self.state.lock().await.persistent.current_term;
+        let resp = handlers::handle_install_snapshot(
+            &req,
+            Arc::clone(&self.state),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(error=?e, "Failed to handle InstallSnapshot");
+            InstallSnapshotResponse { term: Term::new(0) }
+        });
+        notify_heartbeat(
+            req.term,
+            req.leader_id,
+            current_term,
+            &self.heartbeat_tx,
+        );
+        resp
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,51 +1,7 @@
-use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Sampler};
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};
-
-/// Trait for RPC context types that can be enriched with distributed tracing information.
-///
-/// This trait provides a type-safe way to propagate OpenTelemetry trace context
-/// to various RPC frameworks without coupling the tracing logic to a specific framework.
-pub trait TraceContextInjector: Sized {
-    /// Injects the current OpenTelemetry span context into this RPC context.
-    fn with_current_trace(self) -> Self;
-}
-
-/// Implementation for tarpc's Context type.
-impl TraceContextInjector for tarpc::context::Context {
-    fn with_current_trace(mut self) -> Self {
-        // Get the current OpenTelemetry span context
-        let otel_ctx = tracing_opentelemetry::OpenTelemetrySpanExt::context(
-            &tracing::Span::current(),
-        );
-        let span_ref = otel_ctx.span();
-        let span_ctx = span_ref.span_context();
-
-        // Only propagate if the span context is valid (not a no-op span)
-        if span_ctx.is_valid() {
-            let trace_id = span_ctx.trace_id();
-            let span_id = span_ctx.span_id();
-            let is_sampled = span_ctx.trace_flags().is_sampled();
-
-            self.trace_context = tarpc::trace::Context {
-                trace_id: tarpc::trace::TraceId::from(u128::from_be_bytes(
-                    trace_id.to_bytes(),
-                )),
-                span_id: tarpc::trace::SpanId::from(u64::from_be_bytes(
-                    span_id.to_bytes(),
-                )),
-                sampling_decision: if is_sampled {
-                    tarpc::trace::SamplingDecision::Sampled
-                } else {
-                    tarpc::trace::SamplingDecision::Unsampled
-                },
-            };
-        }
-
-        self
-    }
-}
 
 pub fn init_tracing(
     service_name: &'static str,
@@ -63,8 +19,6 @@ pub fn init_tracing(
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(1.0);
 
-    // ParentBased sampler: follows parent span's sampling decision if present,
-    // otherwise uses TraceIdRatioBased sampling
     let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
         sampling_ratio,
     )));
@@ -126,8 +80,6 @@ pub fn init_tracing_stderr(
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(0.1);
 
-    // ParentBased sampler: follows parent span's sampling decision if present,
-    // otherwise uses TraceIdRatioBased sampling
     let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
         sampling_ratio,
     )));

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -19,6 +19,8 @@ pub fn init_tracing(
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(1.0);
 
+    // ParentBased sampler: follows parent span's sampling decision if present,
+    // otherwise uses TraceIdRatioBased sampling
     let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
         sampling_ratio,
     )));
@@ -80,6 +82,8 @@ pub fn init_tracing_stderr(
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(0.1);
 
+    // ParentBased sampler: follows parent span's sampling decision if present,
+    // otherwise uses TraceIdRatioBased sampling
     let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
         sampling_ratio,
     )));

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
-use tarpc::serde::{Deserialize, Serialize};
 
 #[derive(
     Debug,
@@ -14,7 +14,6 @@ use tarpc::serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
 )]
-#[serde(crate = "tarpc::serde")]
 pub struct Term(u32);
 
 impl Term {
@@ -56,7 +55,6 @@ impl From<u32> for Term {
     Serialize,
     Deserialize,
 )]
-#[serde(crate = "tarpc::serde")]
 pub struct NodeId(u32);
 
 impl NodeId {
@@ -100,7 +98,6 @@ impl From<u16> for NodeId {
     Serialize,
     Deserialize,
 )]
-#[serde(crate = "tarpc::serde")]
 pub struct LogIndex(u32);
 
 impl LogIndex {


### PR DESCRIPTION
## Why

- tarpc は Rust エコシステム内でニッチであり、他言語クライアント対応や標準ツール（grpcurl, health check）が使えない
- tonic は `opentelemetry-otlp` 経由で既に間接依存しており、追加コストが小さい

## What

- RPC フレームワークを tarpc から tonic (gRPC) に完全移行
- `proto/raft.proto` + `build.rs` で gRPC サービス定義とコード生成を追加
- `tarpc::context::Context` の代替として独自 `RpcContext` 型を導入
- RPC 境界での prost 生成型 ⇔ 内部 serde 型の変換レイヤーを実装
- tarpc, futures 依存を完全削除